### PR TITLE
Remove @tiptap/core dependency and update imports

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -16,7 +16,6 @@
     "@halo-dev/components": "^2.21.0",
     "@halo-dev/console-shared": "^2.21.0",
     "@halo-dev/richtext-editor": "2.21.0",
-    "@tiptap/core": "^2.26.4",
     "axios": "^1.13.5",
     "vue": "^3.5.17"
   },

--- a/ui/pnpm-lock.yaml
+++ b/ui/pnpm-lock.yaml
@@ -42,9 +42,6 @@ importers:
       '@halo-dev/richtext-editor':
         specifier: 2.21.0
         version: 2.21.0(vue@3.5.17(typescript@5.8.3))
-      '@tiptap/core':
-        specifier: ^2.26.4
-        version: 2.27.2(@tiptap/pm@2.27.2)
       axios:
         specifier: 1.13.5
         version: 1.13.5
@@ -1412,9 +1409,6 @@ packages:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
 
-  caniuse-lite@1.0.30001723:
-    resolution: {integrity: sha512-1R/elMjtehrFejxwmexeXAtae5UO9iSyFn6G/I806CYC/BLyyBk1EPhrKBkWhy6wM6Xnm47dSJQec+tLJ39WHw==}
-
   caniuse-lite@1.0.30001786:
     resolution: {integrity: sha512-4oxTZEvqmLLrERwxO76yfKM7acZo310U+v4kqexI2TL1DkkUEMT8UijrxxcnVdxR3qkVf5awGRX+4Z6aPHVKrA==}
 
@@ -2543,10 +2537,6 @@ packages:
     resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
     engines: {node: '>=18'}
 
-  watchpack@2.4.4:
-    resolution: {integrity: sha512-c5EGNOiyxxV5qmTtAB7rbiXxi1ooX1pQKMLX/MIabJjRA0SJBQOjKF+KSVfHkr9U1cADPon0mRiVe/riyaiDUA==}
-    engines: {node: '>=10.13.0'}
-
   watchpack@2.5.1:
     resolution: {integrity: sha512-Zn5uXdcFNIA1+1Ei5McRd+iRzfhENPCe7LeABkJtNulSxjma+l7ltNx55BWZkRlwRnpOgHqxnjyaDgJnNXnqzg==}
     engines: {node: '>=10.13.0'}
@@ -3196,7 +3186,7 @@ snapshots:
       '@module-federation/runtime-tools': 0.14.0
       '@rspack/binding': 1.3.12
       '@rspack/lite-tapable': 1.0.1
-      caniuse-lite: 1.0.30001723
+      caniuse-lite: 1.0.30001786
     optionalDependencies:
       '@swc/helpers': 0.5.17
 
@@ -3880,8 +3870,6 @@ snapshots:
       get-intrinsic: 1.3.0
 
   callsites@3.1.0: {}
-
-  caniuse-lite@1.0.30001723: {}
 
   caniuse-lite@1.0.30001786: {}
 
@@ -5004,7 +4992,7 @@ snapshots:
     dependencies:
       chalk: 4.1.2
       hash-sum: 2.0.0
-      watchpack: 2.4.4
+      watchpack: 2.5.1
       webpack: 5.105.4
     optionalDependencies:
       vue: 3.5.17(typescript@5.8.3)
@@ -5039,11 +5027,6 @@ snapshots:
   w3c-xmlserializer@5.0.0:
     dependencies:
       xml-name-validator: 5.0.0
-
-  watchpack@2.4.4:
-    dependencies:
-      glob-to-regexp: 0.4.1
-      graceful-fs: 4.2.11
 
   watchpack@2.5.1:
     dependencies:

--- a/ui/src/editor/schedule-card-extension.ts
+++ b/ui/src/editor/schedule-card-extension.ts
@@ -1,6 +1,6 @@
 import { ToolboxItem, VueNodeViewRenderer } from '@halo-dev/richtext-editor'
-import { mergeAttributes, Node } from '@tiptap/core'
-import type { Editor, Range } from '@tiptap/core'
+import { mergeAttributes, Node } from '@halo-dev/richtext-editor'
+import type { Editor, Range } from '@halo-dev/richtext-editor'
 import { IconCalendar } from '@halo-dev/components'
 import { markRaw } from 'vue'
 import type { ScheduleCard } from '../types/schedule'


### PR DESCRIPTION
移除 `@tiptap/core`，改为从 `@halo-dev/richtext-editor` 导入，这样可以复用 UI 的依赖，防止与内置的依赖造成冲突，同时降低捆绑包体积。

之前：

<img width="540" height="121" alt="image" src="https://github.com/user-attachments/assets/95751d40-f7b7-4677-98c1-2ca070065ee5" />

现在：

<img width="743" height="134" alt="image" src="https://github.com/user-attachments/assets/bcbf7b56-8b79-42b5-8bf6-10b79f6aa016" />
